### PR TITLE
Resolve outstanding c-api specific Python test failures

### DIFF
--- a/src/unity/toolkits/recsys/models/factorization_models.cpp
+++ b/src/unity/toolkits/recsys/models/factorization_models.cpp
@@ -403,19 +403,4 @@ void recsys_factorization_model_base::internal_load(turi::iarchive& iarc,
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-std::vector<std::string> recsys_factorization_model_base::list_fields() const {
-  return {"coefficients"};
-}
-
-////////////////////////////////////////////////////////////////////////////
-
-std::map<std::string, variant_type> recsys_factorization_model_base::get(const std::string& v) const {
-
-  std::map<std::string, variant_type> ret;
-  ret["coefficients"] = to_variant(model->get_coefficients());
-  return ret;
-}
-
 }}

--- a/src/unity/toolkits/recsys/models/factorization_models.hpp
+++ b/src/unity/toolkits/recsys/models/factorization_models.hpp
@@ -52,10 +52,6 @@ class EXPORT recsys_factorization_model_base : public recsys_model_base {
 
 
  public:
-
-  std::vector<std::string> list_fields() const;
-  std::map<std::string, variant_type> get(const std::string& v) const;
-  
   void score_all_items(
       std::vector<std::pair<size_t, double> >& scores,
       const std::vector<v2::ml_data_entry>& query_row,

--- a/src/unity/toolkits/recsys/recsys_model_base.hpp
+++ b/src/unity/toolkits/recsys/recsys_model_base.hpp
@@ -49,18 +49,6 @@ class EXPORT recsys_model_base : public ml_model_base {
 
   virtual ~recsys_model_base() {}
 
-  ////////////////////////////////////////////////////////////////////////////////
-  //
-  //  Internal functions that are implemented or can be overridden by
-  //  the subclassed model.
-  //
-  ////////////////////////////////////////////////////////////////////////////////
-
-  // A const overload of the non-const base class name() method, which cannot be
-  // const.
-  std::string name() const { return const_cast<recsys_model_base*>(this)->name(); }
-
-
  protected:
 
   /** Train the algorithm.
@@ -82,16 +70,6 @@ class EXPORT recsys_model_base : public ml_model_base {
  public:
   virtual bool use_target_column(bool target_is_present) const = 0;
   virtual bool include_columns_beyond_user_item() const { return false; }
-
-  virtual std::vector<std::string> list_fields() const {
-    return std::vector<std::string>();
-  }
-
-  virtual std::map<std::string, variant_type> get(const std::string& v) const {
-    ASSERT_TRUE(false);
-    return std::map<std::string, variant_type>();
-  }
-
 
  public:
   /** Run predictions on each element in the test data set.  Returns a

--- a/src/unity/toolkits/supervised_learning/xgboost.cpp
+++ b/src/unity/toolkits/supervised_learning/xgboost.cpp
@@ -1085,6 +1085,11 @@ void xgboost_model::train(void) {
   trim_boost_learner(booster_);
 }
 
+enum{
+    XGBOOST_WITH_STATS = 1, //output also gain and cover metrics per node
+    XGBOOST_JSON_FORMAT = 2 //use Json format for output
+};
+
 /**
  * Save the training state as model metadata
  */
@@ -1111,7 +1116,7 @@ void xgboost_model::_save_training_state(size_t iteration,
   // Store trees
   utils::FeatMap fmap;
   MakeFeatMap(fmap, this->ml_mdata);
-  std::vector<flexible_type> trees_json = convert_vec_string(booster_->DumpModel(fmap, 2 /** json **/));
+  std::vector<flexible_type> trees_json = convert_vec_string(booster_->DumpModel(fmap, XGBOOST_JSON_FORMAT | XGBOOST_WITH_STATS));
   info["trees_json"] = trees_json;
   info["num_trees"] = trees_json.size();
   add_or_update_state(flexmap_to_varmap(info));

--- a/test/unity/toolkits/recsys/factorization_test_helpers.hpp
+++ b/test/unity/toolkits/recsys/factorization_test_helpers.hpp
@@ -136,8 +136,7 @@ restart_model_training:
 
   std::vector<model_ptr> all_models =
       {model,
-       model_ptr(new recsys_ranking_factorization_model),
-       model_ptr((recsys::recsys_model_base*)(model->ml_model_base_clone()))};
+       model_ptr(new recsys_ranking_factorization_model)};
 
 
   sframe y_hat_sf_ref = model->predict(model->create_ml_data(train_data));


### PR DESCRIPTION
To resolve recsys-toolkit test failures, the toolkit-function-registration code must be robust to Python dictionaries being converted into flex_dict instead of variant_map_type. Some miscellaneous fallout from the model_base refactoring is also fixed.

To resolve boosted tree test failures, cherry-pick a commit from master that was lost in a merge.