### PR TITLE
EXPERIMENTAL, DO NOT MERGE: alternative implementation of capi_wrappe…

### DIFF
--- a/src/capi/TuriCore.h
+++ b/src/capi/TuriCore.h
@@ -15,6 +15,9 @@ extern "C" {
 /*                                                                            */
 /******************************************************************************/
 
+// Forward reference to polymorphic base class for implementations.
+struct tc_impl_base;
+
 // Error message struct
 struct tc_error_struct;
 typedef struct tc_error_struct tc_error;
@@ -33,8 +36,8 @@ struct tc_flex_dict_struct;
 typedef struct tc_flex_dict_struct tc_flex_dict;
 
 // datetime
-struct tc_datetime_struct;
-typedef struct tc_datetime_struct tc_datetime;
+struct tc_datetime { struct tc_impl_base* impl; };
+typedef struct tc_datetime tc_datetime;
 
 // Image
 struct tc_flex_image_struct;

--- a/src/capi/impl/capi_datetime.cpp
+++ b/src/capi/impl/capi_datetime.cpp
@@ -72,7 +72,7 @@ EXPORT void tc_datetime_set_time_zone_offset(
 
   CHECK_NOT_NULL(error, dt, "Datetime");
 
-  dt->value.set_time_zone_offset(4* n_tz_hour_offset + n_tz_15min_offsets);
+  get_value(dt).set_time_zone_offset(4* n_tz_hour_offset + n_tz_15min_offsets);
 
   ERROR_HANDLE_END(error);
 }
@@ -82,7 +82,7 @@ EXPORT int64_t tc_datetime_get_time_zone_offset_minutes(
 
   CHECK_NOT_NULL(error, dt, "Datetime", 0);
 
-  return dt->value.time_zone_offset() * 15;
+  return get_value(dt).time_zone_offset() * 15;
 
   ERROR_HANDLE_END(error, 0);
 }
@@ -94,7 +94,7 @@ EXPORT void tc_datetime_set_microsecond(
 
   CHECK_NOT_NULL(error, dt, "Datetime");
 
-  dt->value.set_microsecond(microseconds);
+  get_value(dt).set_microsecond(microseconds);
 
   ERROR_HANDLE_END(error);
 }
@@ -104,7 +104,7 @@ EXPORT uint64_t tc_datetime_get_microsecond(
 
   CHECK_NOT_NULL(error, dt, "Datetime", 0);
 
-  return dt->value.microsecond();
+  return get_value(dt).microsecond();
 
   ERROR_HANDLE_END(error, 0);
 }
@@ -117,7 +117,7 @@ EXPORT void tc_datetime_set_timestamp(
 
   CHECK_NOT_NULL(error, dt, "Datetime");
 
-  dt->value.set_posix_timestamp(d);
+  get_value(dt).set_posix_timestamp(d);
 
   ERROR_HANDLE_END(error);
 }
@@ -126,7 +126,7 @@ EXPORT int64_t tc_datetime_get_timestamp(tc_datetime* dt, tc_error** error) {
 
   CHECK_NOT_NULL(error, dt, "Datetime", 0);
 
-  return dt->value.posix_timestamp();
+  return get_value(dt).posix_timestamp();
 
   ERROR_HANDLE_END(error, 0);
 }
@@ -139,7 +139,7 @@ EXPORT void tc_datetime_set_highres_timestamp(
 
   CHECK_NOT_NULL(error, dt, "Datetime");
 
-  dt->value.set_microsecond_res_timestamp(d);
+  get_value(dt).set_microsecond_res_timestamp(d);
 
   ERROR_HANDLE_END(error);
 }
@@ -149,7 +149,7 @@ EXPORT double tc_datetime_get_highres_timestamp(
 
   CHECK_NOT_NULL(error, dt, "Datetime", 0.0);
 
-  return dt->value.microsecond_res_timestamp();
+  return get_value(dt).microsecond_res_timestamp();
 
   ERROR_HANDLE_END(error, 0.0);
 }
@@ -162,7 +162,7 @@ EXPORT int tc_datetime_less_than(
   CHECK_NOT_NULL(error, dt1, "Datetime", false);
   CHECK_NOT_NULL(error, dt2, "Datetime", false);
 
-  return dt1->value < dt2->value;
+  return get_value(dt1) < get_value(dt2);
 
   ERROR_HANDLE_END(error, 0);
 }
@@ -175,14 +175,14 @@ EXPORT int tc_datetime_equal(
   CHECK_NOT_NULL(error, dt1, "Datetime", false);
   CHECK_NOT_NULL(error, dt2, "Datetime", false);
 
-  return dt1->value == dt2->value;
+  return get_value(dt1) == get_value(dt2);
 
   ERROR_HANDLE_END(error, 0);
 }
 
 // Destructor
 EXPORT void tc_datetime_destroy(tc_datetime* dt) {
-  delete dt;
+  delete dt->impl;
 }
 
 }  // extern "C"

--- a/src/capi/impl/capi_flexible_type.cpp
+++ b/src/capi/impl/capi_flexible_type.cpp
@@ -80,7 +80,7 @@ EXPORT tc_flexible_type* tc_ft_create_from_datetime(const tc_datetime* dt, tc_er
   
   CHECK_NOT_NULL(error, dt, "tc_datetime", NULL);
 
-  return new_tc_flexible_type(dt->value);
+  return new_tc_flexible_type(get_value(dt));
 
   ERROR_HANDLE_END(error, NULL);
 }

--- a/src/capi/impl/capi_parameters.cpp
+++ b/src/capi/impl/capi_parameters.cpp
@@ -142,7 +142,7 @@ EXPORT void tc_parameters_add_datetime(tc_parameters* params, const char* name, 
   CHECK_NOT_NULL(error, params, "tc_parameters");
   CHECK_NOT_NULL(error, dt, "tc_datetime");
 
-  params->value[name] = turi::to_variant(dt->value);
+  params->value[name] = turi::to_variant(get_value(dt));
 
   ERROR_HANDLE_END(error); 
 }

--- a/src/capi/impl/capi_variant.cpp
+++ b/src/capi/impl/capi_variant.cpp
@@ -86,9 +86,9 @@ EXPORT tc_variant* tc_variant_create_from_flex_dict(const tc_flex_dict* td, tc_e
 EXPORT tc_variant* tc_variant_create_from_datetime(const tc_datetime* dt, tc_error** error){
   ERROR_HANDLE_START();
 
-  CHECK_NOT_NULL(error, turi::flexible_type(dt->value), "Flex Datetime", NULL);
+  CHECK_NOT_NULL(error, turi::flexible_type(get_value(dt)), "Flex Datetime", NULL);
 
-  return new_tc_variant(turi::flexible_type(dt->value));
+  return new_tc_variant(turi::flexible_type(get_value(dt)));
 
   ERROR_HANDLE_END(error, NULL);
 }

--- a/src/capi/impl/capi_wrapper_structs.cpp
+++ b/src/capi/impl/capi_wrapper_structs.cpp
@@ -4,7 +4,6 @@
   capi_struct_type_info_##struct_name capi_struct_type_info_##struct_name##_inst
 
 DEFINE_CAPI_WRAPPER_STRUCT_TYPE_INFO(tc_error);
-DEFINE_CAPI_WRAPPER_STRUCT_TYPE_INFO(tc_datetime);
 DEFINE_CAPI_WRAPPER_STRUCT_TYPE_INFO(tc_flex_dict);
 DEFINE_CAPI_WRAPPER_STRUCT_TYPE_INFO(tc_flex_list);
 DEFINE_CAPI_WRAPPER_STRUCT_TYPE_INFO(tc_flex_image);

--- a/test/capi/capi_datetime.cxx
+++ b/test/capi/capi_datetime.cxx
@@ -12,7 +12,9 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_create_empty) {
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_DIFFERS(dt, nullptr);
 
-  TS_ASSERT(dt->value == turi::flex_date_time());
+  TS_ASSERT(get_value(dt) == turi::flex_date_time());
+
+  tc_datetime_destroy(dt);
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_create_from_posix_timestamp) {
@@ -24,7 +26,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_create_from_posix_timestamp) {
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_DIFFERS(dt, nullptr);
 
-  TS_ASSERT(dt->value == turi::flex_date_time(TIMESTAMP));
+  TS_ASSERT(get_value(dt) == turi::flex_date_time(TIMESTAMP));
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_create_from_posix_highres_timestamp) {
@@ -39,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_create_from_posix_highres_timestamp) {
 
   turi::flex_date_time expected;
   expected.set_microsecond_res_timestamp(TIMESTAMP);
-  TS_ASSERT(dt->value == expected);
+  TS_ASSERT(get_value(dt) == expected);
 }
 
 #include <iostream>
@@ -54,7 +56,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_create_from_string) {
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_DIFFERS(dt, nullptr);
 
-  TS_ASSERT(dt->value == expected.get<turi::flex_date_time>());
+  TS_ASSERT(get_value(dt) == expected.get<turi::flex_date_time>());
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_set_time_zone_offset) {
@@ -66,7 +68,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_set_time_zone_offset) {
   tc_datetime_set_time_zone_offset(
       dt, hour_offset, quarter_hour_offsets, &error);
   TS_ASSERT_EQUALS(error, nullptr);
-  TS_ASSERT_EQUALS(dt->value.time_zone_offset(),
+  TS_ASSERT_EQUALS(get_value(dt).time_zone_offset(),
                    hour_offset * 4 + quarter_hour_offsets);
 
   hour_offset = 0;
@@ -74,14 +76,14 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_set_time_zone_offset) {
   tc_datetime_set_time_zone_offset(
       dt, hour_offset, quarter_hour_offsets, &error);
   TS_ASSERT_EQUALS(error, nullptr);
-  TS_ASSERT_EQUALS(dt->value.time_zone_offset(),
+  TS_ASSERT_EQUALS(get_value(dt).time_zone_offset(),
                    hour_offset * 4 + quarter_hour_offsets);
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_get_time_zone_offset_minutes) {
   tc_error* error = nullptr;
   tc_datetime* dt = tc_datetime_create_empty(&error);
-  dt->value.set_time_zone_offset(5);
+  get_value(dt).set_time_zone_offset(5);
   int64_t minutes = tc_datetime_get_time_zone_offset_minutes(dt, &error);
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_EQUALS(minutes, 5 * 15);
@@ -94,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_set_microsecond) {
   tc_datetime* dt = tc_datetime_create_empty(&error);
   tc_datetime_set_microsecond(dt, MICROS, &error);
   TS_ASSERT_EQUALS(error, nullptr);
-  TS_ASSERT_EQUALS(dt->value.microsecond(), MICROS);
+  TS_ASSERT_EQUALS(get_value(dt).microsecond(), MICROS);
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_get_microsecond) {
@@ -102,7 +104,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_get_microsecond) {
 
   tc_error* error = nullptr;
   tc_datetime* dt = tc_datetime_create_empty(&error);
-  dt->value.set_microsecond(MICROS);
+  get_value(dt).set_microsecond(MICROS);
   uint64_t micros = tc_datetime_get_microsecond(dt, &error);
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_EQUALS(micros, MICROS);
@@ -115,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_set_timestamp) {
   tc_datetime* dt = tc_datetime_create_empty(&error);
   tc_datetime_set_timestamp(dt, TIMESTAMP, &error);
   TS_ASSERT_EQUALS(error, nullptr);
-  TS_ASSERT_EQUALS(dt->value.posix_timestamp(), TIMESTAMP);
+  TS_ASSERT_EQUALS(get_value(dt).posix_timestamp(), TIMESTAMP);
 }
 
 BOOST_AUTO_TEST_CASE(test_tc_datetime_get_timestamp) {
@@ -123,7 +125,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_get_timestamp) {
 
   tc_error* error = nullptr;
   tc_datetime* dt = tc_datetime_create_empty(&error);
-  dt->value.set_posix_timestamp(TIMESTAMP);
+  get_value(dt).set_posix_timestamp(TIMESTAMP);
   int64_t ts = tc_datetime_get_timestamp(dt, &error);
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_EQUALS(ts, TIMESTAMP);
@@ -136,7 +138,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_set_highres_timestamp) {
   tc_datetime* dt = tc_datetime_create_empty(&error);
   tc_datetime_set_highres_timestamp(dt, TIMESTAMP, &error);
   TS_ASSERT_EQUALS(error, nullptr);
-  TS_ASSERT_DELTA(dt->value.microsecond_res_timestamp(), TIMESTAMP, 0.000002);
+  TS_ASSERT_DELTA(get_value(dt).microsecond_res_timestamp(), TIMESTAMP, 0.000002);
 }
 
 
@@ -145,7 +147,7 @@ BOOST_AUTO_TEST_CASE(test_tc_datetime_get_highres_timestamp) {
 
   tc_error* error = nullptr;
   tc_datetime* dt = tc_datetime_create_empty(&error);
-  dt->value.set_microsecond_res_timestamp(TIMESTAMP);
+  get_value(dt).set_microsecond_res_timestamp(TIMESTAMP);
   double ts = tc_datetime_get_highres_timestamp(dt, &error);
   TS_ASSERT_EQUALS(error, nullptr);
   TS_ASSERT_DELTA(ts, TIMESTAMP, 0.000002);


### PR DESCRIPTION
…r_structs

For now, only implemented for tc_datetime, as an example. What is exposed in the header changes from:
struct tc_datetime_struct;
to:
struct tc_impl_base;
struct tc_datetime { struct tc_impl_base* impl; };

One immediate advantage is that e.g.
void foo(tc_datetime* dt);
is imported into Swift as having type
(UnsafeMutablePointer<tc_datetime>) -> Void
instead of
(OpaquePointer) -> Void

On the implementation side, tc_impl_base can serve as a polymorphic base class allowing us to recover the true type, even if the client messes up and casts the pointers we give them inappropriately.

Thoughts?