### PR TITLE
WIP: CAPI framework build size reduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${TC_BUILD_PYTHON})
   endif()
 
   include(UseCython)
-
+  add_definitions(-DTC_HAS_PYTHON)
 else()
   message("Skipping python libraries.")
 endif()
@@ -131,17 +131,16 @@ if(WIN32)
   add_definitions(-DWINVER=0x0600)
   add_definitions(-D_WIN32_WINNT=0x0600)
 endif()
-add_definitions(-DCURL_STATICLIB)
+
+if(${TC_REMOTEFS})
+  add_definitions(-DTC_HAS_REMOTEFS)
+  add_definitions(-DCURL_STATICLIB)
+else()
+  set(TC_NO_CURL TRUE)
+endif()
 add_definitions(-DIN_TURI_SOURCE_TREE)
 add_definitions(-DFUSION_MAX_VECTOR_SIZE=20)
 add_definitions(-DBOOST_SPIRIT_THREAD_SAFE)
-
-#**************************************************************************/
-#*                                                                        */
-#*                          Apple Legal Defines                           */
-#*                                                                        */
-#**************************************************************************/
-add_definitions(-DEIGEN_MPL2_ONLY)
 
 #**************************************************************************/
 #*                                                                        */
@@ -268,7 +267,12 @@ if(HAS_FTRACER)
 endif()
 
 set(DEBUG_OPTIMIZATION_LEVEL -O0)
-set(RELEASE_OPTIMIZATION_LEVEL -O3)
+
+if(${RELEASE_OPT_FOR_SIZE})
+  set(RELEASE_OPTIMIZATION_LEVEL -Os)
+else()
+  set(RELEASE_OPTIMIZATION_LEVEL -O3)
+endif()
 
 if(WIN32)
         # on windows due to some string table limitations + template

--- a/build_capi.sh
+++ b/build_capi.sh
@@ -118,7 +118,7 @@ function build_capi {
   echo
   echo "Building C-API"
   echo
-  run_configure --with-capi --no-python --no-visualization || exit 1
+  run_configure --with-capi --no-python --no-visualization --no-remotefs --release-opt-for-size -D TC_MINIMAL_TOOLKITS=1 || exit 1
   install_dir=${target_dir}/capi
   rm -rf ${target_dir}/capi
   mkdir -p ${target_dir}/capi
@@ -143,6 +143,11 @@ function build_capi_framework {
   echo "Installing C API Framework to ${target_dir}."
 
   rsync -a --delete ${build_dir}/src/capi/TuriCore.framework/ ${target_dir}/TuriCore.framework/ || exit 1
+
+  if [[ $build_mode == release ]] ; then
+    echo "Stripping local and debug symbols."
+    strip -S -x ${target_dir}/TuriCore.framework/Versions/Current/TuriCore || exit 1
+  fi
 }
 
 

--- a/configure
+++ b/configure
@@ -105,6 +105,8 @@ with_capi=0
 with_capi_framework=0
 with_ccache=1
 with_visualization=1
+with_remotefs=1
+release_opt_for_size=0
 
 python27=0
 python35=0
@@ -119,6 +121,8 @@ while [ $# -gt 0 ]
     --cleanup)              cleanup_option=1;;
     
     --install-python-toolchain) python_only=1;;
+
+    --release-opt-for-size) release_opt_for_size=1;;
     
     --with-system-cmake)    with_system_cmake=1;;
     --no-system-cmake)      with_system_cmake=0;;
@@ -135,6 +139,9 @@ while [ $# -gt 0 ]
 
     --with-visualization)   with_visualization=1;;
     --no-visualization)     with_visualization=0;;
+
+    --with-remotefs)            with_remotefs=1;;
+    --no-remotefs)              with_remotefs=0;;
 
     --yes)                  default_yes=1;;
 
@@ -191,6 +198,10 @@ else
   CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_PYTHON=0"
 fi
 
+if [[ $release_opt_for_size == 1 ]]; then
+  CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DRELEASE_OPT_FOR_SIZE=1"
+fi
+
 # If we need to build python, we also need to install the python toolchain
 if [[ $with_capi == 1 ]]; then
   CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_CAPI=1"
@@ -206,6 +217,12 @@ if [[ $with_visualization == 1 ]]; then
   CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_VISUALIZATION_CLIENT=1"
 else
   CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_BUILD_VISUALIZATION_CLIENT=0"
+fi
+
+
+# If we need to build python, we also need to install the python toolchain
+if [[ $with_remotefs == 1 ]]; then
+  CMAKE_CONFIG_FLAGS="$CMAKE_CONFIG_FLAGS -DTC_REMOTEFS=1"
 fi
 
 

--- a/deps/cmake/ExternalProjectLibCurl.cmake
+++ b/deps/cmake/ExternalProjectLibCurl.cmake
@@ -1,3 +1,7 @@
+if(TC_NO_CURL)
+  return()
+endif()
+
 if(APPLE)
   SET(EXTRA_CONFIGURE_FLAGS --with-darwinssl --without-ssl)
 elseif(WIN32)

--- a/deps/cmake/ExternalProjectOpenSSL.cmake
+++ b/deps/cmake/ExternalProjectOpenSSL.cmake
@@ -1,3 +1,7 @@
+if(TC_NO_CURL)
+  return()
+endif()
+
 if(APPLE)
   # SSL seems to link fine even when compiled using the default compiler
   # The alternative to get openssl to use gcc on mac requires a patch to

--- a/src/cppipc/common/ipc_deserializer.hpp
+++ b/src/cppipc/common/ipc_deserializer.hpp
@@ -5,6 +5,12 @@
  */
 #ifndef CPPIPC_IPC_DESERIALIZER_HPP
 #define CPPIPC_IPC_DESERIALIZER_HPP
+
+#ifdef DISABLE_TURI_CPPIPC_PROXY_GENERATION
+#include <cppipc/common/ipc_deserializer_minimal.hpp>
+
+#else
+
 #include <type_traits>
 #include <serialization/iarchive.hpp>
 #include <cppipc/ipc_object_base.hpp>
@@ -81,17 +87,13 @@ struct deserialize_impl<InArcType, std::shared_ptr<T>, false,
       }
       value = std::static_pointer_cast<T>(obj);
     } else if (client) {
-#ifdef DISABLE_TURI_CPPIPC_PROXY_GENERATION
-      value.reset();
-#else
       size_t object_id;
       iarc >> object_id;
       value.reset(new typename T::proxy_object_type(*client, false, object_id));
-#endif
     }
   }
 };
 } // archive_detail
 } // turicreate
-
+#endif
 #endif

--- a/src/cppipc/common/ipc_deserializer_minimal.hpp
+++ b/src/cppipc/common/ipc_deserializer_minimal.hpp
@@ -1,0 +1,39 @@
+/* Copyright © 2017 Apple Inc. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-3-clause license that can
+ * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
+ */
+#ifndef CPPIPC_IPC_DESERIALIZER_MINIMAL_HPP
+#define CPPIPC_IPC_DESERIALIZER_MINIMAL_HPP
+#include <type_traits>
+#include <serialization/iarchive.hpp>
+#include <cppipc/ipc_object_base.hpp>
+
+namespace turi {
+namespace archive_detail {
+
+template <typename OutArcType, typename T>
+struct serialize_impl<OutArcType, std::shared_ptr<T>, false,
+    typename std::enable_if<std::is_convertible<T*, cppipc::ipc_object_base*>::value>::type
+    > {
+  inline static 
+      void
+      exec(OutArcType& oarc, const std::shared_ptr<T> value) {
+        oarc << (*value);
+  }
+};
+
+
+template <typename InArcType, typename T>
+struct deserialize_impl<InArcType, std::shared_ptr<T>, false,
+    typename std::enable_if<std::is_convertible<T*, cppipc::ipc_object_base*>::value>::type
+    > {
+  inline static 
+      void exec(InArcType& iarc, std::shared_ptr<T>& value) {
+        iarc >> (*value);
+  }
+};
+} // archive_detail
+} // turicreate
+
+#endif

--- a/src/cppipc/magic_macros.hpp
+++ b/src/cppipc/magic_macros.hpp
@@ -5,13 +5,13 @@
  */
 #ifndef CPPIPC_MAGIC_MACROS_HPP
 #define CPPIPC_MAGIC_MACROS_HPP
+#include <cppipc/ipc_object_base.hpp>
+#include <cppipc/registration_macros.hpp>
 #ifndef DISABLE_TURI_CPPIPC_PROXY_GENERATION
+#include <cppipc/server/comm_server.hpp>
 #include <cppipc/client/object_proxy.hpp>
 #include <cppipc/cppipc.hpp>
 #endif
-#include <cppipc/server/comm_server.hpp>
-#include <cppipc/ipc_object_base.hpp>
-#include <cppipc/registration_macros.hpp>
 #include <cppipc/common/ipc_deserializer.hpp>
 #include <serialization/serialization_includes.hpp>
 #include <boost/preprocessor.hpp>

--- a/src/fileio/fileio_constants.cpp
+++ b/src/fileio/fileio_constants.cpp
@@ -11,9 +11,11 @@
 #include <fileio/fs_utils.hpp>
 #include <fileio/temp_files.hpp>
 #include <fileio/block_cache.hpp>
-#include <fileio/hdfs.hpp>
 #include <globals/globals.hpp>
 #include <random/random.hpp>
+#ifdef TC_HAS_REMOTEFS
+#include <fileio/hdfs.hpp>
+#endif
 #include <iostream>
 #include <export.hpp>
 
@@ -76,6 +78,7 @@ static bool check_cache_file_location(std::string val) {
   return true;
 }
 
+#ifdef TC_HAS_REMOTEFS
 static bool check_cache_file_hdfs_location(std::string val) {
   if (get_protocol(val) == "hdfs") {
     if (get_file_status(val) == file_status::DIRECTORY) {
@@ -98,6 +101,7 @@ static bool check_cache_file_hdfs_location(std::string val) {
   }
   throw std::string("Invalid hdfs path: ") + val;
 }
+#endif
 
 EXPORT const size_t FILEIO_INITIAL_CAPACITY_PER_FILE = 1024;
 EXPORT size_t FILEIO_MAXIMUM_CACHE_CAPACITY_PER_FILE = 128 * 1024 * 1024;
@@ -130,11 +134,13 @@ REGISTER_GLOBAL_WITH_CHECKS(std::string,
                             true,
                             check_cache_file_location);
 
+
+#ifdef TC_HAS_REMOTEFS
 REGISTER_GLOBAL_WITH_CHECKS(std::string,
                             CACHE_FILE_HDFS_LOCATION,
                             true,
                             check_cache_file_hdfs_location);
-
+#endif
 std::string get_cache_file_locations() {
   return CACHE_FILE_LOCATIONS; 
 }

--- a/src/fileio/fs_utils.cpp
+++ b/src/fileio/fs_utils.cpp
@@ -128,7 +128,16 @@ std::tuple<std::string, std::string, std::string> parse_hdfs_url(std::string url
 }
 
 EXPORT file_status get_file_status(const std::string& path) {
-  if(boost::starts_with(path, "hdfs://")) {
+  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+    // this is a cache file. it is only REGULAR or MISSING
+    try {
+      fixed_size_cache_manager::get_instance().get_cache(path);
+      return file_status::REGULAR_FILE;
+    } catch (...) {
+      return file_status::MISSING;
+    }
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(path, "hdfs://")) {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -145,14 +154,6 @@ EXPORT file_status get_file_status(const std::string& path) {
       // failure for some reason. fail with missing
       return file_status::MISSING;
     }
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
-    // this is a cache file. it is only REGULAR or MISSING
-    try {
-      fixed_size_cache_manager::get_instance().get_cache(path);
-      return file_status::REGULAR_FILE;
-    } catch (...) {
-      return file_status::MISSING;
-    }
   } else if (boost::starts_with(path, "s3://")) {
     std::pair<bool, bool> ret = is_directory(path);
     if (ret.first == false) return file_status::MISSING;
@@ -161,6 +162,7 @@ EXPORT file_status get_file_status(const std::string& path) {
   } else if (is_web_protocol(get_protocol(path))) {
     return file_status::REGULAR_FILE;
     // some other web protocol?
+#endif
   } else {
     // regular file
     struct stat statout;
@@ -176,7 +178,12 @@ EXPORT file_status get_file_status(const std::string& path) {
 std::vector<std::pair<std::string, file_status>>
 get_directory_listing(const std::string& path) {
   std::vector<std::pair<std::string, file_status> > ret;
-  if(boost::starts_with(path, "hdfs://")) {
+  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+    // this is a cache file. There is no filesystem.
+    // it is only REGULAR or MISSING
+    return ret;
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(path, "hdfs://")) {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -196,10 +203,6 @@ get_directory_listing(const std::string& path) {
     } catch(...) {
       // failure for some reason. return with nothing
     }
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
-    // this is a cache file. There is no filesystem.
-    // it is only REGULAR or MISSING
-    return ret;
   } else if (boost::starts_with(path, "s3://")) {
     list_objects_response response = list_directory(path);
     for (auto dir: response.directories) {
@@ -208,6 +211,7 @@ get_directory_listing(const std::string& path) {
     for (auto obj: response.objects) {
       ret.push_back({obj, file_status::REGULAR_FILE});
     }
+#endif
   } else {
     try {
       fs::path dir(path);
@@ -236,7 +240,11 @@ EXPORT bool create_directory(const std::string& path) {
   if (stat != file_status::MISSING) {
     return false;
   }
-  if(boost::starts_with(path, "hdfs://")) {
+  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+    // this is a cache file. There is no filesystem.
+    return true;
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(path, "hdfs://")) {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -249,12 +257,10 @@ EXPORT bool create_directory(const std::string& path) {
       // failure for some reason. return with nothing
       return false;
     }
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
-    // this is a cache file. There is no filesystem.
-    return true;
   } else if (boost::starts_with(path, "s3://")) {
     // S3 doesn't need directories
     return true;
+#endif
   } else {
     try {
       create_directories(fs::path(path));
@@ -295,7 +301,17 @@ bool delete_path_impl(const std::string& path,
     return false;
   }
   logstream(LOG_INFO) << "Deleting " << sanitize_url(path) << std::endl;
-  if(boost::starts_with(path, "hdfs://")) {
+  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+    try {
+      // we ignore recursive here. since the cache can't hold directories
+      auto cache_entry = fixed_size_cache_manager::get_instance().get_cache(path);
+      fixed_size_cache_manager::get_instance().free(cache_entry);
+      return true;
+    } catch (...) {
+      return false;
+    }
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(path, "hdfs://")) {
     // hdfs only has a recursive deleter. we need to make this safe
     // if the current path is a non-empty directory, fail
     if (stat == file_status::DIRECTORY) {
@@ -315,17 +331,9 @@ bool delete_path_impl(const std::string& path,
       // failure for some reason. return with nothing
       return false;
     }
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
-    try {
-      // we ignore recursive here. since the cache can't hold directories
-      auto cache_entry = fixed_size_cache_manager::get_instance().get_cache(path);
-      fixed_size_cache_manager::get_instance().free(cache_entry);
-      return true;
-    } catch (...) {
-      return false;
-    }
   } else if (boost::starts_with(path, "s3://")) {
     return delete_object(path).empty();
+#endif
   } else {
     try {
       fs::remove(fs::path(path));
@@ -341,10 +349,16 @@ EXPORT bool delete_path_recursive(const std::string& path) {
   file_status stat = get_file_status(path);
   if (stat == file_status::REGULAR_FILE) {
     delete_path(path);
+    return true;
   } else if (stat == file_status::MISSING) {
     return true;
   }
-  if(boost::starts_with(path, "hdfs://")) {
+
+  if (boost::starts_with(path, fileio::get_cache_prefix())) {
+    // recursive deletion not possible with cache
+    return true;
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(path, "hdfs://")) {
     // hdfs
     std::string host, port, hdfspath;
     std::tie(host, port, hdfspath) = parse_hdfs_url(path);
@@ -359,9 +373,7 @@ EXPORT bool delete_path_recursive(const std::string& path) {
     }
   } else if(boost::starts_with(path, "s3://")) {
     return delete_prefix(path).empty();
-  } else if (boost::starts_with(path, fileio::get_cache_prefix())) {
-    // recursive deletion not possible with cache
-    return true;
+#endif
   } else {
     try {
       fs::remove_all(fs::path(path));
@@ -373,8 +385,12 @@ EXPORT bool delete_path_recursive(const std::string& path) {
 }
 
 bool is_writable_protocol(std::string protocol) {
+#ifdef TC_HAS_REMOTEFS
   return protocol == "hdfs" || protocol == "s3" ||
       protocol == "" || protocol == "file" || protocol == "cache";
+#else
+  return protocol == "" || protocol == "file" || protocol == "cache";
+#endif
 }
 
 bool is_web_protocol(std::string protocol) {

--- a/src/fileio/sanitize_url.cpp
+++ b/src/fileio/sanitize_url.cpp
@@ -6,17 +6,23 @@
 #include <string>
 #include <boost/algorithm/string/predicate.hpp>
 #include <fileio/sanitize_url.hpp>
-#include <fileio/s3_api.hpp>
 #include <export.hpp>
+#ifdef TC_HAS_REMOTEFS
+#include <fileio/s3_api.hpp>
+#endif
 
 namespace turi {
 
 EXPORT std::string sanitize_url(std::string url) {
+#ifdef TC_HAS_REMOTEFS
   if (boost::algorithm::starts_with(url, "s3://")) {
     return sanitize_s3_url(url);
   } else {
     return url;
   }
+#else
+    return url;
+#endif
 }
 
 }

--- a/src/fileio/temp_files.cpp
+++ b/src/fileio/temp_files.cpp
@@ -135,6 +135,7 @@ static std::string get_turicreate_temp_directory_prefix() {
   return turicreate_name;
 }
 
+#ifdef TC_HAS_REMOTEFS
 static fs::path get_current_process_hdfs_temp_directory() {
   fs::path path;
   if (fileio::get_cache_file_hdfs_location() != "") {
@@ -144,6 +145,7 @@ static fs::path get_current_process_hdfs_temp_directory() {
   }
   return path;
 }
+#endif
 
 /**
  * Returns the number of temp directories available.
@@ -298,11 +300,14 @@ EXPORT std::string get_temp_name(const std::string& prefix, bool _prefer_hdfs) {
 
   // Local system temp dir
   fs::path path(get_current_process_temp_directory(get_temp_info().temp_file_counter++));
+
+#ifdef TC_HAS_REMOTEFS
   // hdfs temp dir
   fs::path hdfs_path(get_current_process_hdfs_temp_directory());
   if (_prefer_hdfs && !hdfs_path.empty()) {
     path = hdfs_path;
   }
+#endif
   // create the directories if they do not exist
   create_current_process_temp_directory(path.string());
   

--- a/src/fileio/union_fstream.cpp
+++ b/src/fileio/union_fstream.cpp
@@ -6,13 +6,16 @@
 #include <logger/logger.hpp>
 #include <fileio/union_fstream.hpp>
 #include <fileio/cache_stream.hpp>
+
+#ifdef TC_HAS_REMOTEFS
 #include <fileio/s3_fstream.hpp>
 #include <fileio/curl_downloader.hpp>
 #include <fileio/file_download_cache.hpp>
+#include <fileio/hdfs.hpp>
+#endif
 #include <fileio/sanitize_url.hpp>
 #include <boost/algorithm/string.hpp>
 #include <fileio/fs_utils.hpp>
-#include <fileio/hdfs.hpp>
 namespace turi {
 /**
  * A simple union of std::fstream and turi::hdfs::fstream, and turi::fileio::cache_stream.
@@ -34,7 +37,20 @@ union_fstream::union_fstream(std::string url,
 
   bool is_output_stream = (mode & std::ios_base::out);
 
-  if(boost::starts_with(url, "hdfs://")) {
+  if (boost::starts_with(url, fileio::get_cache_prefix())) {
+    // Cache file type
+    type = CACHE;
+    if (is_output_stream) {
+      output_stream.reset(new fileio::ocache_stream(url));
+    } else {
+      auto cachestream = std::make_shared<fileio::icache_stream>(url);
+      input_stream = (*cachestream)->get_underlying_stream();
+      if (input_stream == nullptr) input_stream = cachestream;
+      m_file_size = (*cachestream)->file_size();
+      original_input_stream_handle = std::static_pointer_cast<std::istream>(cachestream);
+    }
+#ifdef TC_HAS_REMOTEFS
+  } else if(boost::starts_with(url, "hdfs://")) {
     // HDFS file type
     type = HDFS;
     std::string host, port, path;
@@ -56,18 +72,6 @@ union_fstream::union_fstream(std::string url,
     } catch(...) {
       log_and_throw_io_failure("Unable to open " + url);
     }
-  } else if (boost::starts_with(url, fileio::get_cache_prefix())) {
-    // Cache file type
-    type = CACHE;
-    if (is_output_stream) {
-      output_stream.reset(new fileio::ocache_stream(url));
-    } else {
-      auto cachestream = std::make_shared<fileio::icache_stream>(url);
-      input_stream = (*cachestream)->get_underlying_stream();
-      if (input_stream == nullptr) input_stream = cachestream;
-      m_file_size = (*cachestream)->file_size();
-      original_input_stream_handle = std::static_pointer_cast<std::istream>(cachestream);
-    }
   } else if (boost::starts_with(url, "s3://")) {
     // the S3 file type currently works by download/uploading a local file
     // i.e. the s3_stream simply remaps a local file stream
@@ -81,6 +85,7 @@ union_fstream::union_fstream(std::string url,
       m_file_size = (*s3stream)->file_size();
       original_input_stream_handle = std::static_pointer_cast<std::istream>(s3stream);
     }
+#endif
   } else {
     // must be local file
     if (is_output_stream) {
@@ -91,6 +96,7 @@ union_fstream::union_fstream(std::string url,
         log_and_throw_io_failure("Cannot open " + url + " for writing");
       }
     } else {
+#ifdef TC_HAS_REMOTEFS
       url = file_download_cache::get_instance().get_file(url);
       input_stream.reset(new std::ifstream(url, std::ifstream::binary));
       if (!input_stream->good()) {
@@ -106,6 +112,9 @@ union_fstream::union_fstream(std::string url,
           m_file_size = fin.tellg();
         }
       }
+#else
+      log_and_throw_io_failure("Cannot open " + url + " for reading");
+#endif
     }
   }
 

--- a/src/sframe_query_engine/operators/all_operators.hpp
+++ b/src/sframe_query_engine/operators/all_operators.hpp
@@ -19,7 +19,9 @@
 #include <sframe_query_engine/operators/union.hpp>
 #include <sframe_query_engine/operators/generalized_union_project.hpp>
 #include <sframe_query_engine/operators/reduce.hpp>
+#ifdef TC_HAS_PYTHON
 #include <sframe_query_engine/operators/lambda_transform.hpp>
+#endif
 #include <sframe_query_engine/operators/optonly_identity_operator.hpp>
 #include <sframe_query_engine/operators/ternary_operator.hpp>
 

--- a/src/sframe_query_engine/operators/operator_properties.cpp
+++ b/src/sframe_query_engine/operators/operator_properties.cpp
@@ -40,8 +40,10 @@ RetType extract_field(planner_node_type ptype, CallArgs... call_args) {
       return FieldExtractionVisitor<planner_node_type::TRANSFORM_NODE>::get(call_args...);
     case planner_node_type::GENERALIZED_TRANSFORM_NODE:
       return FieldExtractionVisitor<planner_node_type::GENERALIZED_TRANSFORM_NODE>::get(call_args...);
+#ifdef TC_HAS_PYTHON
     case planner_node_type::LAMBDA_TRANSFORM_NODE:
       return FieldExtractionVisitor<planner_node_type::LAMBDA_TRANSFORM_NODE>::get(call_args...);
+#endif
     case planner_node_type::UNION_NODE:
       return FieldExtractionVisitor<planner_node_type::UNION_NODE>::get(call_args...);
     case planner_node_type::REDUCE_NODE:

--- a/src/sgraph/sgraph_triple_apply.cpp
+++ b/src/sgraph/sgraph_triple_apply.cpp
@@ -785,7 +785,7 @@ namespace {
     std::vector<size_t> m_mutated_edge_field_ids;
   }; // end of batch edge triple apply visitor
 
-
+#ifdef TC_HAS_PYTHON
   /**************************************************************************/
   /*                                                                        */
   /*                 Implementation of lambda triple apply                  */
@@ -980,6 +980,8 @@ namespace {
 
     sgraph_synchronize m_graph_sync;
   }; // end of lambda_triple_apply_edge_visitor
+
+#endif
   
   }// end of empty namespace 
 
@@ -1025,6 +1027,7 @@ namespace {
     compute.run(visitor);
   }
 
+#ifdef TC_HAS_PYTHON
   /**
    * The actual triple apply API with python lambda.
    */
@@ -1039,6 +1042,7 @@ namespace {
     lambda_triple_apply_visitor visitor(lambda_str, lock_array, srcid_column, dstid_column);
     compute.run(visitor);
   }
+#endif
 
 } // end of sgraph_compute
 } // end of grahlab

--- a/src/sgraph/sgraph_triple_apply.hpp
+++ b/src/sgraph/sgraph_triple_apply.hpp
@@ -124,6 +124,7 @@ void triple_apply(sgraph& g,
                   bool requires_vertex_id = true);
 
 
+#ifdef TC_HAS_PYTHON
 /**
  * Overload. Uses python lambda function.
  */
@@ -131,7 +132,7 @@ void triple_apply(sgraph& g, const std::string& lambda_str,
                   const std::vector<std::string>& mutated_vertex_fields,
                   const std::vector<std::string>& mutated_edge_fields = {});
 
-
+#endif
 
 
 /**************************************************************************/

--- a/src/startup_teardown/startup_teardown.cpp
+++ b/src/startup_teardown/startup_teardown.cpp
@@ -25,8 +25,10 @@
 #include <parallel/thread_pool.hpp>
 #include <logger/logger.hpp>
 #include <logger/log_rotate.hpp>
+#ifdef TC_HAS_PYTHON
 #include <lambda/lambda_master.hpp>
 #include <lambda/graph_pylambda_master.hpp>
+#endif
 #include <minipsutil/minipsutil.h>
 
 #include "startup_teardown.hpp"
@@ -248,12 +250,16 @@ void global_teardown::perform_teardown() {
   teardown_performed = true;
   logstream(LOG_INFO) << "Performing teardown" << std::endl;
   try {
+#ifdef TC_HAS_PYTHON
     turi::lambda::lambda_master::shutdown_instance();
     turi::lambda::graph_pylambda_master::shutdown_instance();
+#endif
     MEMORY_RELEASE_THREAD->stop();
     delete MEMORY_RELEASE_THREAD;
     turi::fileio::fixed_size_cache_manager::get_instance().clear();
+#ifdef TC_HAS_REMOTEFS
     turi::file_download_cache::get_instance().clear();
+#endif
     turi::block_cache::release_instance();
     turi::reap_current_process_temp_files();
     turi::reap_unused_temp_files();

--- a/src/unity/lib/unity_global.cpp
+++ b/src/unity/lib/unity_global.cpp
@@ -15,11 +15,13 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/searching/boyer_moore.hpp>
+#include <boost/filesystem/path.hpp>
 #include <parallel/lambda_omp.hpp>
 #include <fileio/temp_files.hpp>
-#include <fileio/curl_downloader.hpp>
 #include <fileio/fs_utils.hpp>
+#ifdef TC_HAS_PYTHON
 #include <lambda/lambda_master.hpp>
+#endif
 #include <unity/lib/version.hpp>
 #include <unity/lib/unity_global.hpp>
 #include <perf/memory_info.hpp>
@@ -416,28 +418,37 @@ namespace turi {
 
   flexible_type unity_global::eval_lambda(const std::string& string, const flexible_type& arg) {
     log_func_entry();
+#ifdef TC_HAS_PYTHON
     lambda::lambda_master& evaluator = lambda::lambda_master::get_instance();
     auto lambda_hash = evaluator.make_lambda(string);
     std::vector<flexible_type> return_val;
     evaluator.bulk_eval(lambda_hash, {arg}, return_val, false, 0);
     evaluator.release_lambda(lambda_hash);
     return return_val[0];
+#else
+    log_and_throw("Python lambdas not supported");
+#endif
   }
 
   flexible_type unity_global::eval_dict_lambda(const std::string& lambda_string,
                             const std::vector<std::string>& keys,
                             const std::vector<flexible_type>& values) {
     log_func_entry();
+#ifdef TC_HAS_PYTHON
     lambda::lambda_master& evaluator = lambda::lambda_master::get_instance();
     auto lambda_hash = evaluator.make_lambda(lambda_string);
     std::vector<flexible_type> return_val;
     evaluator.bulk_eval(lambda_hash, keys, {values}, return_val, false, 0);
     evaluator.release_lambda(lambda_hash);
     return return_val[0];
+#else
+    log_and_throw("Python lambdas not supported");
+#endif
   }
 
   std::vector<flexible_type> unity_global::parallel_eval_lambda(const std::string& string, const std::vector<flexible_type>& arg) {
     log_func_entry();
+#ifdef TC_HAS_PYTHON
     lambda::lambda_master& evaluator = lambda::lambda_master::get_instance();
     auto lambda_hash = evaluator.make_lambda(string);
 
@@ -451,6 +462,9 @@ namespace turi {
 
     evaluator.release_lambda(lambda_hash);
     return ret;
+#else
+    log_and_throw("Python lambdas not supported");
+#endif
   }
 
   std::string unity_global::__read__(const std::string& url) {

--- a/src/unity/lib/unity_sarray.cpp
+++ b/src/unity/lib/unity_sarray.cpp
@@ -15,7 +15,6 @@
 #include <unity/lib/unity_global_singleton.hpp>
 #include <unity/lib/variant.hpp>
 #include <fileio/temp_files.hpp>
-#include <fileio/curl_downloader.hpp>
 #include <fileio/sanitize_url.hpp>
 #include <fileio/fs_utils.hpp>
 #include <util/file_line_count_estimator.hpp>
@@ -431,7 +430,7 @@ std::shared_ptr<unity_sarray_base> unity_sarray::transform(const std::string& la
                                                            bool skip_undefined,
                                                            int seed) {
   log_func_entry();
-
+#ifdef TC_HAS_PYTHON
   // create a le_transform operator to lazily evaluate this
   auto lambda_node =
       query_eval::op_lambda_transform::
@@ -444,6 +443,9 @@ std::shared_ptr<unity_sarray_base> unity_sarray::transform(const std::string& la
   auto ret_unity_sarray = std::make_shared<unity_sarray>();
   ret_unity_sarray->construct_from_planner_node(lambda_node);
   return ret_unity_sarray;
+#else
+  log_and_throw("Python functions not supported");
+#endif
 }
 
 

--- a/src/unity/lib/unity_sframe.cpp
+++ b/src/unity/lib/unity_sframe.cpp
@@ -32,7 +32,6 @@
 #include <sframe_query_engine/algorithm/ec_sort.hpp>
 #include <sframe_query_engine/algorithm/groupby_aggregate.hpp>
 #include <sframe_query_engine/operators/operator_properties.hpp>
-#include <lambda/pylambda_function.hpp>
 #include <exceptions/error_types.hpp>
 #include <unity/lib/visualization/process_wrapper.hpp>
 #include <unity/lib/visualization/histogram.hpp>
@@ -48,6 +47,9 @@
 #include <boost/archive/iterators/transform_width.hpp>
 #include <logger/logger.hpp>
 
+#ifdef TC_HAS_PYTHON
+#include <lambda/pylambda_function.hpp>
+#endif
 namespace turi {
 
 using namespace turi::query_eval;
@@ -581,6 +583,7 @@ std::shared_ptr<unity_sarray_base> unity_sframe::transform(const std::string& la
                                            bool skip_undefined, // unused
                                            int random_seed) {
   log_func_entry();
+#ifdef TC_HAS_PYTHON
   auto new_planner_node = op_lambda_transform::make_planner_node(
       this->get_planner_node(), lambda, type,
       this->column_names(),
@@ -589,6 +592,9 @@ std::shared_ptr<unity_sarray_base> unity_sframe::transform(const std::string& la
   std::shared_ptr<unity_sarray> ret(new unity_sarray());
   ret->construct_from_planner_node(new_planner_node);
   return ret;
+#else
+  log_and_throw("Python functions not supported");
+#endif
 }
 
 std::shared_ptr<unity_sarray_base> unity_sframe::transform_native(const function_closure_info& toolkit_fn_name,
@@ -639,6 +645,7 @@ std::shared_ptr<unity_sframe_base> unity_sframe::flat_map(
     std::vector<flex_type_enum> column_types,
     bool skip_undefined,
     int seed) {
+#ifdef TC_HAS_PYTHON
   log_func_entry();
   DASSERT_EQ(column_names.size(), column_types.size());
   DASSERT_TRUE(!column_names.empty());
@@ -686,6 +693,9 @@ std::shared_ptr<unity_sframe_base> unity_sframe::flat_map(
   auto ret = std::make_shared<unity_sframe>();
   ret->construct_from_sframe(out_sf);
   return ret;
+#else
+  log_and_throw("Python lambda functions not supported");
+#endif
 }
 
 

--- a/src/unity/lib/unity_sgraph.cpp
+++ b/src/unity/lib/unity_sgraph.cpp
@@ -472,6 +472,7 @@ unity_sgraph::select_edge_fields(const std::vector<std::string>& fields,
 std::shared_ptr<unity_sgraph_base>
 unity_sgraph::lambda_triple_apply(const std::string& lambda_str,
                                   const std::vector<std::string>& mutated_fields) {
+#ifdef TC_HAS_PYTHON
   log_func_entry();
   if (mutated_fields.empty()) {
     log_and_throw("mutated_fields cannot be empty");
@@ -498,6 +499,9 @@ unity_sgraph::lambda_triple_apply(const std::string& lambda_str,
   sgraph_compute::triple_apply(*g, lambda_str, mutated_vertex_fields, mutated_edge_fields);
   std::shared_ptr<unity_sgraph> ret(new unity_sgraph(g));
   return ret;
+#else
+  log_and_throw("Python functions not supported");
+#endif
 }
 
 

--- a/src/unity/python/turicreate/cython/cy_server.pyx
+++ b/src/unity/python/turicreate/cython/cy_server.pyx
@@ -16,6 +16,7 @@ import sys
 from libcpp.string cimport string
 from cy_cpp_utils cimport str_to_cpp, cpp_to_str
 from .python_printer_callback import print_callback
+from .. import connect as _connect
 
 cdef extern from "<unity/server/unity_server_control.hpp>" namespace "turi":
     cdef cppclass unity_server_options:

--- a/src/unity/server/registration.cpp
+++ b/src/unity/server/registration.cpp
@@ -45,6 +45,12 @@
 namespace turi {
 
 void register_functions(toolkit_function_registry& registry) {
+
+  registry.register_toolkit_function(turi::evaluation::get_toolkit_function_registration());
+  registry.register_toolkit_function(turi::supervised::get_toolkit_function_registration());
+  registry.register_toolkit_function(turi::sdk_model::activity_classification::get_toolkit_function_registration());
+
+#ifndef TC_MINIMAL_TOOLKITS
   registry.register_toolkit_function(image_util::get_toolkit_function_registration());
   registry.register_toolkit_function(visualization::get_toolkit_function_registration());
 

--- a/src/unity/server/unity_server.cpp
+++ b/src/unity/server/unity_server.cpp
@@ -9,8 +9,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
-#include <cppipc/cppipc.hpp>
-#include <cppipc/common/authentication_token_method.hpp>
 #include <minipsutil/minipsutil.h>
 #include <logger/logger.hpp>
 #include <logger/log_rotate.hpp>
@@ -19,8 +17,9 @@
 #include <unity/lib/toolkit_class_registry.hpp>
 #include <unity/lib/toolkit_function_registry.hpp>
 #include <startup_teardown/startup_teardown.hpp>
-
+#ifdef TC_HAS_PYTHON
 #include <lambda/lambda_master.hpp>
+#endif
 
 #include "unity_server.hpp"
 
@@ -60,7 +59,9 @@ void unity_server::start(const unity_server_initializer& server_initializer) {
   // initialize extension modules and lambda workers
   server_initializer.init_extensions(options.root_path, unity_global_ptr);
 
+#ifdef TC_HAS_PYTHON
   lambda::set_pylambda_worker_binary_from_environment_variables();
+#endif
 
   log_thread.launch([=]() {
                       do {

--- a/src/unity/server/unity_server_control.cpp
+++ b/src/unity/server/unity_server_control.cpp
@@ -3,7 +3,6 @@
  * Use of this source code is governed by a BSD-3-clause license that can
  * be found in the LICENSE.txt file or at https://opensource.org/licenses/BSD-3-Clause
  */
-#include <cppipc/client/comm_client.hpp>
 #include <logger/logger.hpp>
 #include <logger/assertions.hpp>
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
Several techniques to reduce the overall size of C API framework:

* Limit the toolkits that are included
* Remove curl, openssl, and remote filesystem support
* Use -Os (optimize for size)
* Strip binaries
* etc.

Note: does not build currently. At least one build break of the form:
```
In file included from /Users/zach/turicreate/src/external/aws-sdk-cpp/aws-cpp-sdk-core/source/utils/crypto/factory/Factories.cpp:24:
/Users/zach/turicreate/src/external/aws-sdk-cpp/aws-cpp-sdk-core/include/aws/core/utils/crypto/openssl/CryptoImpl.h:22:10: fatal error: 'openssl/ossl_typ.h' file not found
#include <openssl/ossl_typ.h>
         ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```