### PR TITLE
Fix build breaks in variant.hpp

### DIFF
--- a/src/unity/lib/variant.hpp
+++ b/src/unity/lib/variant.hpp
@@ -109,8 +109,9 @@ struct deserialize_impl<iarchive, turi::variant_type, false> {
 
 namespace turi {
 // A list of accessors to help Cython access the variant
-  template <typename T>
-void _throw_variant_error(const variant_type& v) GL_COLD_NOINLINE {
+template <typename T>
+GL_COLD_NOINLINE 
+void _throw_variant_error(const variant_type& v) {
     std::string errormsg =  //
         std::string("Variant type error: Expecting ") +
         get_variant_which_name(variant_type(T()).which()) + " but got a " +
@@ -156,104 +157,104 @@ static inline bool variant_is(const variant_type&) {
 }
 
 template <>
-static inline bool variant_is<flexible_type>(const variant_type& t) {
+inline bool variant_is<flexible_type>(const variant_type& t) {
    return t.which() == 0;
 }
 
 template <>
-static inline bool variant_is<flex_string>(const variant_type& t) {
+inline bool variant_is<flex_string>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::STRING);
 }
 
 template <>
-static inline bool variant_is<flex_vec>(const variant_type& t) {
+inline bool variant_is<flex_vec>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::VECTOR);
 }
 
 template <>
-static inline bool variant_is<flex_int>(const variant_type& t) {
+inline bool variant_is<flex_int>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::INTEGER);
 }
 
 template <>
-static inline bool variant_is<flex_float>(const variant_type& t) {
+inline bool variant_is<flex_float>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::FLOAT);
 }
 
 template <>
-static inline bool variant_is<flex_list>(const variant_type& t) {
+inline bool variant_is<flex_list>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::LIST);
 }
 
 template <>
-static inline bool variant_is<flex_dict>(const variant_type& t) {
+inline bool variant_is<flex_dict>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::DICT);
 }
 
 template <>
-static inline bool variant_is<flex_image>(const variant_type& t) {
+inline bool variant_is<flex_image>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::IMAGE);
 }
 
 template <>
-static inline bool variant_is<flex_date_time>(const variant_type& t) {
+inline bool variant_is<flex_date_time>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::DATETIME);
 }
 template <>
-static inline bool variant_is<flex_nd_vec>(const variant_type& t) {
+inline bool variant_is<flex_nd_vec>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::ND_VECTOR);
 }
 template <>
-static inline bool variant_is<flex_undefined>(const variant_type& t) {
+inline bool variant_is<flex_undefined>(const variant_type& t) {
    return variant_is<flexible_type>(t) && (variant_get_ref<flexible_type>(t).get_type() == flex_type_enum::UNDEFINED);
 }
 
 template <>
-static inline bool variant_is<std::shared_ptr<unity_sgraph_base> >(const variant_type& t) {
+inline bool variant_is<std::shared_ptr<unity_sgraph_base> >(const variant_type& t) {
    return t.which() == 1;
 }
 
 template <>
-static inline bool variant_is<dataframe_t>(const variant_type& t) {
+inline bool variant_is<dataframe_t>(const variant_type& t) {
    return t.which() == 2;
 }
 
 template <>
-static inline bool variant_is<std::shared_ptr<model_base> >(const variant_type& t) {
+inline bool variant_is<std::shared_ptr<model_base> >(const variant_type& t) {
    return t.which() == 3;
 }
 
 template <>
-static inline bool variant_is<std::shared_ptr<unity_sframe_base> >(const variant_type& t) {
+inline bool variant_is<std::shared_ptr<unity_sframe_base> >(const variant_type& t) {
    return t.which() == 4;
 }
 
 class gl_sframe; 
 
 template <>
-static inline bool variant_is<gl_sframe>(const variant_type& t) {
+inline bool variant_is<gl_sframe>(const variant_type& t) {
    return t.which() == 4;
 }
 
 template <>
-static inline bool variant_is<std::shared_ptr<unity_sarray_base> >(const variant_type& t) {
+inline bool variant_is<std::shared_ptr<unity_sarray_base> >(const variant_type& t) {
    return t.which() == 5;
 }
 
 class gl_sarray; 
 
 template <>
-static inline bool variant_is<gl_sarray>(const variant_type& t) {
+inline bool variant_is<gl_sarray>(const variant_type& t) {
    return t.which() == 5;
 }
 
 template <>
-static inline bool variant_is<variant_map_type>(const variant_type& t) {
+inline bool variant_is<variant_map_type>(const variant_type& t) {
    return t.which() == 6;
 }
 
 template <>
-static inline bool variant_is<boost::recursive_wrapper<function_closure_info> >(const variant_type& t) {
+inline bool variant_is<boost::recursive_wrapper<function_closure_info> >(const variant_type& t) {
    return t.which() == 7;
 }
 


### PR DESCRIPTION
The latest c-api-merge branch breaks with some errors on GCC:

```
In file included from /builds/turi/turicreate-build/src/logger/logger.hpp:52:0,
                 from /builds/turi/turicreate-build/src/logger/assertions.hpp:60,
                 from /builds/turi/turicreate-build/src/serialization/iarchive.hpp:16,
                 from /builds/turi/turicreate-build/src/serialization/serialize.hpp:8,
                 from /builds/turi/turicreate-build/src/serialization/serialization_includes.hpp:6,
                 from /builds/turi/turicreate-build/src/platform/parallel/atomic.hpp:12,
                 from /builds/turi/turicreate-build/src/flexible_type/flexible_type.hpp:15,
                 from /builds/turi/turicreate-build/src/unity/lib/gl_sframe.hpp:14,
                 from /builds/turi/turicreate-build/src/unity/lib/visualization/boxes_and_whiskers.hpp:9,
                 from /builds/turi/turicreate-build/src/unity/lib/visualization/boxes_and_whiskers.cpp:6:
/builds/turi/turicreate-build/src/unity/lib/variant.hpp:113:50: error: attributes are not allowed on a function-definition
```

```
In file included from /builds/turi/turicreate-build/src/unity/lib/toolkit_util.hpp:11:0,
                 from /builds/turi/turicreate-build/src/unity/lib/toolkit_class_macros.hpp:9,
                 from /builds/turi/turicreate-build/src/unity/lib/visualization/plot.hpp:4,
                 from /builds/turi/turicreate-build/src/unity/lib/visualization/boxes_and_whiskers.hpp:11,
                 from /builds/turi/turicreate-build/src/unity/lib/visualization/boxes_and_whiskers.cpp:6:
/builds/turi/turicreate-build/src/unity/lib/variant.hpp:159:1: error: explicit template specialization cannot have a storage class
 static inline bool variant_is<flexible_type>(const variant_type& t) {
 ^
```